### PR TITLE
[Events] Add optional  ChannelInterface parameter in DecoratorInterface

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -7,6 +7,9 @@ in all versions (major and minor)
 To get the diff for a specific change, go to https://github.com/PandaPlatform/framework/commit/XXX where
 XXX is the change hash
 
+* 2.1.7 (2018-10-17)
+  * [Events] Add ChannelInterface as optional parameter in decorate function on DecorateInterface
+
 * 2.1.6 (2018-10-17)
   * [Helpers] Remove passing by reference in ArrayHelper::merge()
   

--- a/src/Panda/Events/Event.php
+++ b/src/Panda/Events/Event.php
@@ -39,10 +39,11 @@ abstract class Event implements EventInterface, DecoratorInterface
 
     /**
      * @param MessageInterface $message
+     * @param ChannelInterface $channel
      *
      * @return MessageInterface
      */
-    abstract public function decorate(MessageInterface $message);
+    abstract public function decorate(MessageInterface $message, ChannelInterface $channel = null);
 
     /**
      * @param ChannelInterface    $channel

--- a/src/Panda/Events/Messages/DecoratorInterface.php
+++ b/src/Panda/Events/Messages/DecoratorInterface.php
@@ -11,6 +11,8 @@
 
 namespace Panda\Events\Messages;
 
+use Panda\Events\Channels\ChannelInterface;
+
 /**
  * Interface DecoratorInterface
  * @package Panda\Events\Messages
@@ -19,8 +21,9 @@ interface DecoratorInterface
 {
     /**
      * @param MessageInterface $message
+     * @param ChannelInterface $channel
      *
      * @return MessageInterface
      */
-    public function decorate(MessageInterface $message);
+    public function decorate(MessageInterface $message, ChannelInterface $channel = null);
 }

--- a/src/Panda/Events/Subscriber.php
+++ b/src/Panda/Events/Subscriber.php
@@ -40,10 +40,11 @@ abstract class Subscriber implements SubscriberInterface, DecoratorInterface
 
     /**
      * @param MessageInterface $message
+     * @param ChannelInterface $channel
      *
      * @return MessageInterface
      */
-    abstract public function decorate(MessageInterface $message);
+    abstract public function decorate(MessageInterface $message, ChannelInterface $channel = null);
 
     /**
      * @param EventInterface   $event


### PR DESCRIPTION
Add ChannelInterface as second parameter (optional) so the decorate can decorate the message based on channel ( viber, sms, email, etc) 