### PR TITLE
[Framework] Introduce optional info logger

### DIFF
--- a/CHANGELOG-2.1.md
+++ b/CHANGELOG-2.1.md
@@ -7,6 +7,9 @@ in all versions (major and minor)
 To get the diff for a specific change, go to https://github.com/PandaPlatform/framework/commit/XXX where
 XXX is the change hash
 
+* 2.1.12
+  * [Framework] Introduce optional info logger handler
+
 * 2.1.11
   * [Events] Add try..catch on decorate call when dispatching events
 

--- a/src/Panda/Bootstrap/Logging.php
+++ b/src/Panda/Bootstrap/Logging.php
@@ -77,6 +77,12 @@ class Logging implements BootLoader
                 $logger->pushHandler(new RotatingFileHandler($path, $loggerConfig['max_files_count'], Logger::DEBUG));
             }
 
+            // Add info handler
+            if (!empty($loggerConfig['info'])) {
+                $path = $basePath . DIRECTORY_SEPARATOR . $loggerConfig['info'];
+                $logger->pushHandler(new RotatingFileHandler($path, $loggerConfig['max_files_count'], Logger::INFO));
+            }
+
             // Add error handler
             if (!empty($loggerConfig['error'])) {
                 $path = $basePath . DIRECTORY_SEPARATOR . $loggerConfig['error'];


### PR DESCRIPTION
The goal of this PR is to allow the user to create info logs that will be separate from the debug/error logs.